### PR TITLE
Adding queue operations in purescript-redis

### DIFF
--- a/src/Cache.js
+++ b/src/Cache.js
@@ -175,6 +175,28 @@ var setMessageHandlerJ = function(client) {
   }
 }
 
+var enqueueJ = function(client) {
+  return function(listname) {
+    return function(value) {
+      return client.rpushAsync(listname, value);
+    }
+  }
+}
+
+var dequeueJ = function(client) {
+  return function(listname) {
+    return client.lpopAsync(listname);
+  }
+}
+
+var getQueueIdxJ = function(client) {
+  return function(listname) {
+    return function(index) {
+      return client.lindexAsync(listname, index);
+    }
+  }
+}
+
 exports._newCache = _newCache;
 exports.setJ = setJ;
 exports.setKeyJ = setKeyJ;
@@ -188,3 +210,6 @@ exports.getHashKeyJ = getHashKeyJ;
 exports.publishToChannelJ = publishToChannelJ;
 exports.subscribeJ = subscribeJ;
 exports.setMessageHandlerJ = setMessageHandlerJ;
+exports.enqueueJ = enqueueJ;
+exports.dequeueJ = dequeueJ;
+exports.getQueueIdxJ = getQueueIdxJ;

--- a/src/Cache.purs
+++ b/src/Cache.purs
@@ -86,6 +86,9 @@ foreign import publishToChannelJ :: CacheConn -> String -> String -> Promise Str
 foreign import subscribeJ :: forall eff. CacheConn -> String -> Eff eff (Promise String)
 foreign import setMessageHandlerJ :: forall eff1 eff2. CacheConn -> (String -> String -> Eff eff1 Unit) -> Eff eff2 (Promise String)
 foreign import _newCache :: forall e. Foreign -> Eff ( cache :: CACHE | e ) CacheConn
+foreign import enqueueJ :: CacheConn -> String -> String -> Promise String
+foreign import dequeueJ :: CacheConn -> String -> Promise String
+foreign import getQueueIdxJ :: CacheConn -> String -> Int -> Promise String
 
 getConn :: forall e. Options CacheConnOpts -> Aff ( cache :: CACHE | e ) CacheConn
 getConn = liftEff <<< _newCache <<< options
@@ -125,6 +128,15 @@ publishToChannel cacheConn channel message = attempt $ toAff $ publishToChannelJ
 
 subscribe :: forall e. CacheConn -> String -> Aff (cache :: CACHE | e) (Either Error String)
 subscribe cacheConn channel = attempt $ toAffE $ subscribeJ cacheConn channel
+
+enqueue :: forall e. CacheConn -> String -> String -> Aff (cache :: CACHE | e) (Either Error String)
+enqueue cacheConn listName value = attempt $ toAff $ enqueueJ cacheConn listName value
+
+dequeue :: forall e. CacheConn -> String -> Aff (cache :: CACHE | e) (Either Error String)
+dequeue cacheConn listName = attempt $ toAff $ dequeueJ cacheConn listName
+
+getQueueIdx :: forall e. CacheConn -> String -> Int -> Aff (cache :: CACHE | e) (Either Error String)
+getQueueIdx cacheConn listName index = attempt $ toAff $ getQueueIdxJ cacheConn listName index
 
 setMessageHandler :: forall e eff. CacheConn -> (String -> String -> Eff eff Unit) -> Aff (cache :: CACHE | e) (Either Error String)
 setMessageHandler cacheConn f = attempt $ toAffE $ setMessageHandlerJ cacheConn f

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,9 +1,11 @@
 module Test.Main where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+
+import Cache (dequeue, enqueue, getQueueIdx)
+import Cache (host, port, db, socketKeepAlive, getConn, CACHE, setex, enqueue, dequeue, getQueueIdx) as C
 import Control.Monad.Aff (Aff, launchAff)
-import Cache (host, port, db, socketKeepAlive, getConn, CACHE, setex) as C
+import Control.Monad.Eff (Eff)
 import Data.Options (options, (:=))
 import Debug.Trace (spy)
 
@@ -13,8 +15,12 @@ startTest :: forall e. Aff _ Unit
 startTest = do
     let cacheOpts = C.host := "127.0.0.1" <> C.port := 6379 <> C.db := 0 <> C.socketKeepAlive := true
     cacheConn <- C.getConn cacheOpts
-    v <- C.setex cacheConn "talk" "i am awesome" "10000"
-    _ <- pure $ spy v
+    -- v <- C.setex cacheConn "talk" "i am awesome" "10000"
+    -- l <- C.enqueue cacheConn "DBACTIONS" "SELCT * FROM CUSTOMERS;"
+    -- pop <- C.dequeue cacheConn "DBACTIONS"
+    peek <- C.getQueueIdx cacheConn "DBACTIONS" 0
+    _ <- pure $ spy peek
+    _ <- pure $ spy $ "It worked"
     pure unit
 
 main :: forall e. Eff _ Unit


### PR DESCRIPTION
Adding 3 operations:
enqueue, dequeue and getQueueIdx(peek a particular index)

Internally, 
enqueue will do RPUSH on the queue.
dequeue will do LPOP on the queue.
getQueueIdx will do LINDEX on the queue.