### PR TITLE
Make set return a Boolean instead of Unit

### DIFF
--- a/src/Cache.purs
+++ b/src/Cache.purs
@@ -48,7 +48,7 @@ import Control.Monad.Eff.Exception (Error)
 import Control.Promise (Promise, toAff)
 import Data.Array.NonEmpty (NonEmptyArray, toArray)
 import Data.Either (Either)
-import Data.Foreign (Foreign)
+import Data.Foreign (Foreign, isNull)
 import Data.Foreign.NullOrUndefined (undefined)
 import Data.Function.Uncurried (Fn2, Fn3, Fn5, runFn2, runFn3, runFn5)
 import Data.Int (round)
@@ -73,7 +73,7 @@ socketKeepAlive = opt "keepAlive"
 retryStrategy :: Option SimpleConnOpts (SimpleConnOpts -> Int)
 retryStrategy = opt "retryStrategy"
 
-foreign import setJ :: forall a. Fn5 a String String String String (Promise String)
+foreign import setJ :: forall a. Fn5 a String String String String (Promise Foreign)
 foreign import getJ :: forall a. Fn2 a String (Promise Foreign)
 foreign import existsJ :: forall a. Fn2 a String (Promise Int)
 foreign import delJ :: forall a. Fn2 a (Array String) (Promise Int)
@@ -93,11 +93,16 @@ duplicateConn :: forall e. SimpleConn -> Maybe (Options SimpleConnOpts) -> Cache
 duplicateConn cacheConn Nothing     = attempt <<< toAff $ runFn2 _duplicateCache cacheConn undefined
 duplicateConn cacheConn (Just opts) = attempt <<< toAff $ runFn2 _duplicateCache cacheConn (options opts)
 
-set :: forall a e. CacheConn a => a -> String -> String -> Maybe Milliseconds -> SetOptions -> CacheAff e (Either Error Unit)
+set :: forall a e. CacheConn a => a -> String -> String -> Maybe Milliseconds -> SetOptions -> CacheAff e (Either Error Boolean)
 set cacheConn key value mExp opts =
-  attempt <<< void <<< toAff $ runFn5 setJ cacheConn key value (maybe "" msToString mExp) (show opts)
+  attempt <<< map parseSetResult <<< toAff $ runFn5 setJ cacheConn key value (maybe "" msToString mExp) (show opts)
   where
         msToString = show <<< round <<< unwrap
+
+        parseSetResult res | isNull res = false -- Failed because exists (when NX) or not exists (when EX)
+        parseSetResult res              = case readStringMaybe res of
+                                               Just "OK" -> true  -- All good
+                                               otherwise -> false -- This should not happen
 
 get :: forall a e. CacheConn a => a -> String -> CacheAff e (Either Error (Maybe String))
 get cacheConn key = attempt <<< map readStringMaybe <<< toAff $ runFn2 getJ cacheConn key

--- a/test/Basic.purs
+++ b/test/Basic.purs
@@ -59,6 +59,12 @@ basicTest cacheConn =
         checkValue v7 1
         checkValue v8 3
 
+        v9 <- set cacheConn testKey1 "3" Nothing IfNotExist
+        checkValue v9 false
+
+        v10 <- set cacheConn testKey1 "3" Nothing IfExist
+        checkValue v10 true
+
         -- Clean up
         _ <- del cacheConn $ testKey : testKey1 : singleton testKey2
         pure unit


### PR DESCRIPTION
Because set can legitimately fail without an error for the NX and EX
cases, we should signal those failures in the return value.

This also clarifies that the return value from JavaScript is not always
a string, but may be null if the NX/EX set fails. We now correctly
handle that.

Added tests for both cases.