### PR TITLE
Make set return a Boolean instead of Unit

### DIFF
--- a/test/Basic.purs
+++ b/test/Basic.purs
@@ -59,6 +59,12 @@ basicTest cacheConn =
         checkValue v7 1
         checkValue v8 3
 
+        v9 <- set cacheConn testKey1 "3" Nothing IfNotExist
+        checkValue v9 false
+
+        v10 <- set cacheConn testKey1 "3" Nothing IfExist
+        checkValue v10 true
+
         -- Clean up
         _ <- del cacheConn $ testKey : testKey1 : singleton testKey2
         pure unit


### PR DESCRIPTION
Because set can legitimately fail without an error for the NX and EX
cases, we should signal those failures in the return value.

This also clarifies that the return value from JavaScript is not always
a string, but may be null if the NX/EX set fails. We now correctly
handle that.

Added tests for both cases.